### PR TITLE
NIFI-3628  allow override additions for extention and id prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,31 @@ the main 'nifi' code tree.
   go to the [nifi](../nifi) directory and follow its instructions. 
 
 
+## Settings and configuration
+
+There are several properties that can be set to change the behavior of this plugin.
+Two of special interest are:
+
+####type
+type defines the type of archive to be produced and evaluated for special dependencies.  The default type is nar.  This property should be changed if you have need to 
+customize the file extension of archives produced by this plugin.  This plugin will build archives with .nar extentions, and look for othe .nar dependencies by definition.
+Changing this value, for example to 'foo', will have the effect of having the plugin produce archives with .foo as the extension, and look for .foo files
+as nar dependencies.
+ 
+####packageIDPrefix 
+The archives produced by this plugin have the following entries added to the manifest ( where packageIDPrefix defaults to 'Nar'):
+
+-  {packageIDPrefix}-Id
+-  {packageIDPrefix}-Group
+-  {packageIDPrefix}-Version
+-  {packageIDPrefix}-Dependency-Group
+-  {packageIDPrefix}-Dependency-Id
+-  {packageIDPrefix}-Dependency-Version
+
+This property can be used to change the name of these manifest entries
+
+ 
+
 ## Getting Help
 If you have questions, you can reach out to our mailing list: dev@nifi.apache.org
 ([archive](http://mail-archives.apache.org/mod_mbox/nifi-dev)).

--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ The archives produced by this plugin have the following entries added to the man
 -  {packageIDPrefix}-Dependency-Id
 -  {packageIDPrefix}-Dependency-Version
 
-This property can be used to change the name of these manifest entries
+This property can be used to change the name of these manifest entries.  One convention being to continue as the original by capitalizing the
+type, such as:
+Nar to nar
 
  
 

--- a/src/main/java/org/apache/nifi/NarMojo.java
+++ b/src/main/java/org/apache/nifi/NarMojo.java
@@ -112,6 +112,11 @@ public class NarMojo extends AbstractMojo {
      */
     @Parameter(alias = "narName", property = "nar.finalName", defaultValue = "${project.build.finalName}", required = true)
     protected String finalName;
+    /**
+     * Name of the prefix for package identifiers like Nar-Id, where Nar is the identifier
+     */
+    @Parameter(alias = "packageIDPrefix", property = "nar.packageIDPrefix", defaultValue = "Nar", required = true)
+    protected String packageIDPrefix;
 
     /**
      * The Jar archiver.
@@ -480,8 +485,8 @@ public class NarMojo extends AbstractMojo {
         filter.addFilter(new GroupIdFilter(this.includeGroupIds, this.excludeGroupIds));
         filter.addFilter(new ArtifactIdFilter(this.includeArtifactIds, this.excludeArtifactIds));
 
-        // explicitly filter our nar dependencies
-        filter.addFilter(new TypeFilter("", "nar"));
+        // explicitly filter our nar dependencies as defined by type
+        filter.addFilter(new TypeFilter("", type));
 
         // start with all artifacts.
         Set artifacts = project.getArtifacts();
@@ -610,9 +615,9 @@ public class NarMojo extends AbstractMojo {
             }
 
             // automatically add the artifact id, group id, and version to the manifest
-            archive.addManifestEntry("Nar-Id", narId);
-            archive.addManifestEntry("Nar-Group", narGroup);
-            archive.addManifestEntry("Nar-Version", narVersion);
+            archive.addManifestEntry(packageIDPrefix + "-Id", narId);
+            archive.addManifestEntry(packageIDPrefix + "-Group", narGroup);
+            archive.addManifestEntry(packageIDPrefix + "-Version", narVersion);
 
             // look for a nar dependency
             NarDependency narDependency = getNarDependency();
@@ -621,9 +626,9 @@ public class NarMojo extends AbstractMojo {
                 final String narDependencyId = notEmpty(this.narDependencyId) ? this.narDependencyId : narDependency.getArtifactId();
                 final String narDependencyVersion = notEmpty(this.narDependencyVersion) ? this.narDependencyVersion : narDependency.getVersion();
 
-                archive.addManifestEntry("Nar-Dependency-Group", narDependencyGroup);
-                archive.addManifestEntry("Nar-Dependency-Id", narDependencyId);
-                archive.addManifestEntry("Nar-Dependency-Version", narDependencyVersion);
+                archive.addManifestEntry(packageIDPrefix + "-Dependency-Group", narDependencyGroup);
+                archive.addManifestEntry(packageIDPrefix + "-Dependency-Id", narDependencyId);
+                archive.addManifestEntry(packageIDPrefix + "-Dependency-Version", narDependencyVersion);
             }
 
             // add build information when available
@@ -675,7 +680,7 @@ public class NarMojo extends AbstractMojo {
             classifier = "-" + classifier;
         }
 
-        return new File(basedir, finalName + classifier + ".nar");
+        return new File(basedir, finalName + classifier + "." + type );
     }
 
     private NarDependency getNarDependency() throws MojoExecutionException {
@@ -683,7 +688,7 @@ public class NarMojo extends AbstractMojo {
 
         // get nar dependencies
         FilterArtifacts filter = new FilterArtifacts();
-        filter.addFilter(new TypeFilter("nar", ""));
+        filter.addFilter(new TypeFilter(type, ""));
 
         // start with all artifacts.
         Set artifacts = project.getArtifacts();

--- a/src/main/java/org/apache/nifi/NarProvidedDependenciesMojo.java
+++ b/src/main/java/org/apache/nifi/NarProvidedDependenciesMojo.java
@@ -53,8 +53,6 @@ import java.util.Map;
 @Mojo(name = "provided-nar-dependencies", defaultPhase = LifecyclePhase.PACKAGE, threadSafe = false, requiresDependencyResolution = ResolutionScope.RUNTIME)
 public class NarProvidedDependenciesMojo extends AbstractMojo {
 
-    private static final String NAR = "nar";
-
     /**
      * The Maven project.
      */
@@ -79,6 +77,15 @@ public class NarProvidedDependenciesMojo extends AbstractMojo {
      */
     @Parameter(property = "mode", defaultValue = "tree")
     private String mode;
+
+    /**
+     * The type we are using for dependencies, should be nar, but may
+     * be changed in the configuration if the plugin is producing
+     * other archive extensions, this is a 'shared' configuration
+     * with the NarMojo
+     */
+    @Parameter(property = "type", required = false, defaultValue = "nar")
+    protected String type;
 
     /**
      * The dependency tree builder to use for verbose output.
@@ -108,7 +115,7 @@ public class NarProvidedDependenciesMojo extends AbstractMojo {
             // find the nar dependency
             Artifact narArtifact = null;
             for (final Artifact artifact : project.getDependencyArtifacts()) {
-                if (NAR.equals(artifact.getType())) {
+                if (type.equals(artifact.getType())) {
                     // ensure the project doesn't have two nar dependencies
                     if (narArtifact != null) {
                         throw new MojoExecutionException("Project can only have one NAR dependency.");
@@ -141,7 +148,7 @@ public class NarProvidedDependenciesMojo extends AbstractMojo {
             // will be used as the parent classloader for this nar and seeing what
             // dependencies are provided is critical.
             final Map<String, ArtifactHandler> narHandlerMap = new HashMap<>();
-            narHandlerMap.put(NAR, narHandler);
+            narHandlerMap.put(type, narHandler);
             artifactHandlerManager.addHandlers(narHandlerMap);
 
             // get the dependency tree
@@ -294,7 +301,7 @@ public class NarProvidedDependenciesMojo extends AbstractMojo {
             }
 
             final Artifact artifact = node.getArtifact();
-            if (!NAR.equals(artifact.getType())) {
+            if (!type.equals(artifact.getType())) {
                 output.append("<dependency>\n");
                 output.append("    <groupId>").append(artifact.getGroupId()).append("</groupId>\n");
                 output.append("    <artifactId>").append(artifact.getArtifactId()).append("</artifactId>\n");


### PR DESCRIPTION
This PR introduces the ability to change the extension name though changing the type property as well as specifying the prefix on the Nar-XXXX manifest entries.

The type property is used to specify the file extension, and hardcoded instances of 'nar' are changed to use this property consistantly.

The property is also used in the NarDependencyMojo, such that the hardcoded NAR='nar' usage is changed to use the type property.   The configuration of this property will govern both mojos.

The defaults are all left as [N,n]ar.  Such that there are NO required changes to existing POMs or archetypes to continue working after this change.

This was tested by building building the archetype, and building nifi with the pom reference changed to the version built ( validating from the logs the plugin version used ).

All tests run and pass

Nifi was run from the assembly dir, and a flow created, logs viewed to verify that there were no errors loading / unpacking the nars, running the flows.


The changes proposed here would allow for other projects to use nar formatted archives while specializing them to fit that project.  The Apache Metron project would like to use this plugin, and these changes would make that possible from a single code base / plugin, without duplication of effort for something that is the same.
