### PR TITLE
NIFI-4930: Resolve issues when fetching nar files from artifact repos…

### DIFF
--- a/src/main/java/org/apache/nifi/NarMojo.java
+++ b/src/main/java/org/apache/nifi/NarMojo.java
@@ -702,7 +702,7 @@ public class NarMojo extends AbstractMojo {
         } else if (artifacts.size() == 1) {
             final Artifact artifact = (Artifact) artifacts.iterator().next();
 
-            narDependency = new NarDependency(artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion());
+            narDependency = new NarDependency(artifact.getGroupId(), artifact.getArtifactId(), artifact.getBaseVersion());
         }
 
         return narDependency;


### PR DESCRIPTION
…itories like artifactory

The NAR Maven Plugin 1.2.0 is using artifact.getVersion() to determine the Nar-Dependency-Version, however this version number can be a timestamped snapshot version number if the dependency was downloaded from a remote repo. The Nar-Dependency-Version can then differ from the declared Nar-Version in the other JAR.

Signed-off-by: Derek Straka <derek@asterius.io>