### PR TITLE
NIFI-5304 - Changed Lifecycle Phase Binding for Help Mojo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -355,7 +355,7 @@
                         <goals>
                             <goal>helpmojo</goal>
                         </goals>
-                        <phase>process-classes</phase>
+                        <phase>generate-sources</phase>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Moved Maven Plugin Plugin help Mojo from "process-classes" to
"generate-sources" lifecycle phase to ensure the help Mojo is included
in the built plugin.