### PR TITLE
NIFI-4216 Marked mojos as ThreadSafe

### DIFF
--- a/src/main/java/org/apache/nifi/NarMojo.java
+++ b/src/main/java/org/apache/nifi/NarMojo.java
@@ -78,7 +78,7 @@ import org.codehaus.plexus.util.StringUtils;
  * simplified to the use case of NarMojo.
  *
  */
-@Mojo(name = "nar", defaultPhase = LifecyclePhase.PACKAGE, threadSafe = false, requiresDependencyResolution = ResolutionScope.RUNTIME)
+@Mojo(name = "nar", defaultPhase = LifecyclePhase.PACKAGE, threadSafe = true, requiresDependencyResolution = ResolutionScope.RUNTIME)
 public class NarMojo extends AbstractMojo {
 
     private static final String[] DEFAULT_EXCLUDES = new String[]{"**/package.html"};

--- a/src/main/java/org/apache/nifi/NarProvidedDependenciesMojo.java
+++ b/src/main/java/org/apache/nifi/NarProvidedDependenciesMojo.java
@@ -50,7 +50,7 @@ import java.util.Map;
  * not project those dependences using the traditional maven dependency plugin. This plugin will override that setting in order to print the dependencies being
  * inherited at runtime.
  */
-@Mojo(name = "provided-nar-dependencies", defaultPhase = LifecyclePhase.PACKAGE, threadSafe = false, requiresDependencyResolution = ResolutionScope.RUNTIME)
+@Mojo(name = "provided-nar-dependencies", defaultPhase = LifecyclePhase.PACKAGE, threadSafe = true, requiresDependencyResolution = ResolutionScope.RUNTIME)
 public class NarProvidedDependenciesMojo extends AbstractMojo {
 
     private static final String NAR = "nar";


### PR DESCRIPTION
Marked both mojos as `ThreadSafe`.