### PR TITLE
NIFI-5859 Fixing bug in doc generation that called getId() instead of…

### DIFF
--- a/src/main/java/org/apache/nifi/NarMojo.java
+++ b/src/main/java/org/apache/nifi/NarMojo.java
@@ -703,7 +703,7 @@ public class NarMojo extends AbstractMojo {
             final ServiceAPIDefinition serviceAPIDefinition = new StandardServiceAPIDefinition(
                     serviceDefinitionClass.getName(),
                     narArtifact.getGroupId(),
-                    narArtifact.getId(),
+                    narArtifact.getArtifactId(),
                     narArtifact.getBaseVersion()
             );
 


### PR DESCRIPTION
… getArtifactId()