### PR TITLE
Fix ? when determine provided dependency version

### DIFF
--- a/src/main/java/org/apache/nifi/extension/definition/extraction/ExtensionClassLoaderFactory.java
+++ b/src/main/java/org/apache/nifi/extension/definition/extraction/ExtensionClassLoaderFactory.java
@@ -176,8 +176,8 @@ public class ExtensionClassLoaderFactory {
 
                 for (final Artifact dependency : artifactDependencies) {
                     if (dependency.getGroupId().equals(groupId) && dependency.getArtifactId().equals(artifactId)) {
-                        getLog().debug("Found version of " + groupId + ":" + artifactId + " to be " + artifact.getVersion());
-                        return artifact.getVersion();
+                        getLog().debug("Found version of " + groupId + ":" + artifactId + " to be " + dependency.getVersion());
+                        return dependency.getVersion();
                     }
                 }
             } catch (final Exception e) {


### PR DESCRIPTION
Not sure if it is the correct way and if this is the root cause.
But, when creating a custom maven project with version 0.0.1-SNAPSHOT.

And if in a project there is a provided description on nifi-api, for example on 1.11.4 version, the NAR generation failed wwith something like this in the stack trace :

[DEBUG] building maven31 dependency graph for MY_GROUP_ID:MY_ARTIFACT_ID:jar:0.0.1-SNAPSHOT with Maven31DependencyGraphBuilder
[DEBUG] Dependency collection stats: {ConflictMarker.analyzeTime=11500, ConflictMarker.markTime=10100, ConflictMarker.nodeCount=13, ConflictIdSorter.graphTime=4900, ConflictIdSorter.topsortTime=9000, ConflictIdSorter.conflictIdCount=11, ConflictIdSorter.conflictIdCycleCount=0, ConflictResolver.totalTime=42300, ConflictResolver.conflictItemCount=12, DefaultDependencyCollector.collectTime=395400, DefaultDependencyCollector.transformTime=92200}
[DEBUG] MY_GROUP_ID:MY_ARTIFACT_ID:jar:0.0.1-SNAPSHOT
[DEBUG]    org.apache.nifi:nifi-api:jar:1.11.4:provided
[DEBUG]    junit:junit:jar:4.13:test
[DEBUG]       org.hamcrest:hamcrest-core:jar:1.3:test
[DEBUG]    org.mockito:mockito-core:jar:2.28.2:test
[DEBUG]       net.bytebuddy:byte-buddy:jar:1.9.10:test
[DEBUG]       net.bytebuddy:byte-buddy-agent:jar:1.9.10:test
[DEBUG]       org.objenesis:objenesis:jar:2.6:test
[DEBUG]    org.slf4j:slf4j-simple:jar:1.7.30:test
[DEBUG]       org.slf4j:slf4j-api:jar:1.7.30:provided (scope managed from compile) (version managed from 1.7.30)
[DEBUG]    org.codehaus.groovy:groovy-test:jar:2.5.4:test
[DEBUG]       org.codehaus.groovy:groovy:jar:2.5.4:test
[DEBUG] For Artifact MY_GROUP_ID:MY_ARTIFACT_ID:jar:0.0.1-SNAPSHOT:compile, found the following dependencies:
[DEBUG] org.slf4j:slf4j-api:jar:1.7.30:provided
[DEBUG] org.codehaus.groovy:groovy-test:jar:2.5.4:test
[DEBUG] net.bytebuddy:byte-buddy:jar:1.9.10:test
[DEBUG] junit:junit:jar:4.13:test
[DEBUG] org.apache.nifi:nifi-api:jar:1.11.4:provided
[DEBUG] org.hamcrest:hamcrest-core:jar:1.3:test
[DEBUG] org.objenesis:objenesis:jar:2.6:test
[DEBUG] org.slf4j:slf4j-simple:jar:1.7.30:test
[DEBUG] net.bytebuddy:byte-buddy-agent:jar:1.9.10:test
[DEBUG] org.mockito:mockito-core:jar:2.28.2:test
[DEBUG] MY_GROUP_ID:MY_ARTIFACT_ID:jar:0.0.1-SNAPSHOT
[DEBUG] org.codehaus.groovy:groovy:jar:2.5.4:test
[DEBUG] Found version of org.apache.nifi:nifi-api to be 0.0.1-SNAPSHOT
[INFO] Found a dependency on version 0.0.1-SNAPSHOT of NiFi API