### PR TITLE
NIFI-11217 Fix building external NARs with transitive dependencies...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -340,6 +340,25 @@
             <scope>provided</scope>
             <version>3.3</version>
         </dependency>
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.12.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>3.12.4</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <profiles>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.18</version>
+                    <version>3.0.0-M8</version>
                     <configuration>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
                         <argLine>-Xmx1G</argLine>

--- a/src/main/java/org/apache/nifi/NarMojo.java
+++ b/src/main/java/org/apache/nifi/NarMojo.java
@@ -850,15 +850,16 @@ public class NarMojo extends AbstractMojo {
 
     private ExtensionClassLoaderFactory createClassLoaderFactory() {
         return new ExtensionClassLoaderFactory.Builder()
-            .artifactResolver(resolver)
-            .dependencyGraphBuilder(dependencyGraphBuilder)
-            .localRepository(local)
-            .log(getLog())
-            .project(project)
-            .projectBuilder(projectBuilder)
-            .repositorySession(repoSession)
-            .artifactHandlerManager(artifactHandlerManager)
-            .build();
+                .artifactResolver(resolver)
+                .dependencyGraphBuilder(dependencyGraphBuilder)
+                .localRepository(local)
+                .remoteRepositories(remoteRepos)
+                .log(getLog())
+                .project(project)
+                .projectBuilder(projectBuilder)
+                .repositorySession(repoSession)
+                .artifactHandlerManager(artifactHandlerManager)
+                .build();
     }
 
 

--- a/src/main/java/org/apache/nifi/extension/definition/extraction/ExtensionClassLoaderFactory.java
+++ b/src/main/java/org/apache/nifi/extension/definition/extraction/ExtensionClassLoaderFactory.java
@@ -67,6 +67,7 @@ public class ExtensionClassLoaderFactory {
     private final RepositorySystemSession repoSession;
     private final ProjectBuilder projectBuilder;
     private final ArtifactRepository localRepo;
+    private final List<ArtifactRepository> remoteRepos;
     private final DependencyGraphBuilder dependencyGraphBuilder;
     private final ArtifactResolver artifactResolver;
     private final ArtifactHandlerManager artifactHandlerManager;
@@ -77,6 +78,7 @@ public class ExtensionClassLoaderFactory {
         this.repoSession = builder.repositorySession;
         this.projectBuilder = builder.projectBuilder;
         this.localRepo = builder.localRepo;
+        this.remoteRepos = new ArrayList<>(builder.remoteRepos);
         this.dependencyGraphBuilder = builder.dependencyGraphBuilder;
         this.artifactResolver = builder.artifactResolver;
         this.artifactHandlerManager = builder.artifactHandlerManager;
@@ -213,6 +215,7 @@ public class ExtensionClassLoaderFactory {
 
         final ArtifactResolutionRequest request = new ArtifactResolutionRequest();
         request.setLocalRepository(localRepo);
+        request.setRemoteRepositories(remoteRepos);
         request.setArtifact(artifact);
 
         final ArtifactResolutionResult result = artifactResolver.resolve(request);
@@ -323,6 +326,7 @@ public class ExtensionClassLoaderFactory {
 
             final ArtifactResolutionRequest request = new ArtifactResolutionRequest();
             request.setLocalRepository(localRepo);
+            request.setRemoteRepositories(remoteRepos);
             request.setArtifact(artifact);
 
             final ArtifactResolutionResult result = artifactResolver.resolve(request);
@@ -354,6 +358,7 @@ public class ExtensionClassLoaderFactory {
         private Log log;
         private MavenProject project;
         private ArtifactRepository localRepo;
+        private List<ArtifactRepository> remoteRepos;
         private DependencyGraphBuilder dependencyGraphBuilder;
         private ArtifactResolver artifactResolver;
         private ProjectBuilder projectBuilder;
@@ -377,6 +382,11 @@ public class ExtensionClassLoaderFactory {
 
         public Builder localRepository(final ArtifactRepository localRepo) {
             this.localRepo = localRepo;
+            return this;
+        }
+
+        public Builder remoteRepositories(final List<ArtifactRepository> remoteRepos) {
+            this.remoteRepos = remoteRepos;
             return this;
         }
 

--- a/src/test/java/org/apache/nifi/extension/definition/extraction/ExtensionClassLoaderFactoryTest.java
+++ b/src/test/java/org/apache/nifi/extension/definition/extraction/ExtensionClassLoaderFactoryTest.java
@@ -29,6 +29,8 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
 import org.eclipse.aether.RepositorySystemSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
@@ -54,8 +56,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class ExtensionClassLoaderFactoryTest
-{
+class ExtensionClassLoaderFactoryTest {
 
     @Mock private Log log;
     @Mock private ArtifactResolver artifactResolver;
@@ -73,7 +74,7 @@ class ExtensionClassLoaderFactoryTest
     // Test Subject
     private ExtensionClassLoaderFactory factory;
 
-    @org.junit.jupiter.api.BeforeEach
+    @BeforeEach
     void setUp() {
         artifact1 = projectArtifact();
         artifact2 = localRepositoryDependencyArtifact();
@@ -96,7 +97,7 @@ class ExtensionClassLoaderFactoryTest
                 .build();
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void createClassLoaderTest() throws Exception {
         Set<Artifact> dependencyArtifacts = new TreeSet<>();
         dependencyArtifacts.add(localRepositoryDependencyArtifact());

--- a/src/test/java/org/apache/nifi/extension/definition/extraction/ExtensionClassLoaderFactoryTest.java
+++ b/src/test/java/org/apache/nifi/extension/definition/extraction/ExtensionClassLoaderFactoryTest.java
@@ -29,7 +29,10 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
 import org.eclipse.aether.RepositorySystemSession;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.File;
 import java.net.URL;
@@ -50,39 +53,31 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class ExtensionClassLoaderFactoryTest
 {
-    // Mocks
+
+    @Mock private Log log;
+    @Mock private ArtifactResolver artifactResolver;
+    @Mock private ArtifactRepository localRepository;
+    @Mock private ArtifactRepository remoteRepository;
+    @Mock private ArtifactHandlerManager artifactHandlerManager;
+    @Mock private DependencyGraphBuilder dependencyGraphBuilder;
+    @Mock private MavenProject project;
+    @Mock private ProjectBuilder projectBuilder;
+    @Mock private RepositorySystemSession repositorySession;
     private Artifact artifact1;
     private Artifact artifact2;
     private Artifact artifact3;
-    private Log log;
-    private ArtifactResolver artifactResolver;
-    private ArtifactRepository localRepository;
-    private ArtifactRepository remoteRepository;
-    private ArtifactHandlerManager artifactHandlerManager;
-    private DependencyGraphBuilder dependencyGraphBuilder;
-    private MavenProject project;
-    private ProjectBuilder projectBuilder;
-    private RepositorySystemSession repositorySession;
 
     // Test Subject
     private ExtensionClassLoaderFactory factory;
 
     @org.junit.jupiter.api.BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         artifact1 = projectArtifact();
         artifact2 = localRepositoryDependencyArtifact();
         artifact3 = remoteRepositoryDependencyArtifact();
-        log = mock(Log.class);
-        artifactResolver = mock(ArtifactResolver.class);
-        localRepository = mock(ArtifactRepository.class);
-        remoteRepository = mock(ArtifactRepository.class);
-        artifactHandlerManager = mock(ArtifactHandlerManager.class);
-        dependencyGraphBuilder = mock(DependencyGraphBuilder.class);
-        project = mock(MavenProject.class);
-        projectBuilder = mock(ProjectBuilder.class);
-        repositorySession = mock(RepositorySystemSession.class);
 
         when(artifactResolver.resolve(any(ArtifactResolutionRequest.class)))
                 .thenAnswer(args -> resolved(args.getArgument(0, ArtifactResolutionRequest.class).getArtifact()));
@@ -107,7 +102,7 @@ class ExtensionClassLoaderFactoryTest
         dependencyArtifacts.add(localRepositoryDependencyArtifact());
         dependencyArtifacts.add(remoteRepositoryDependencyArtifact());
 
-        ExtensionClassLoader classLoader = factory.createClassLoader(dependencyArtifacts, null, projectArtifact());
+        ExtensionClassLoader classLoader = factory.createClassLoader(dependencyArtifacts, null, artifact1);
 
         String[] expectedURLs = new String[]{
                 "/path/to/service-api-nar",

--- a/src/test/java/org/apache/nifi/extension/definition/extraction/ExtensionClassLoaderFactoryTest.java
+++ b/src/test/java/org/apache/nifi/extension/definition/extraction/ExtensionClassLoaderFactoryTest.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.extension.definition.extraction;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.resolver.ArtifactResolutionRequest;
+import org.apache.maven.artifact.resolver.ArtifactResolutionResult;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
+import org.eclipse.aether.RepositorySystemSession;
+import org.mockito.InOrder;
+
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+class ExtensionClassLoaderFactoryTest
+{
+    // Mocks
+    private Artifact artifact1;
+    private Artifact artifact2;
+    private Artifact artifact3;
+    private Log log;
+    private ArtifactResolver artifactResolver;
+    private ArtifactRepository localRepository;
+    private ArtifactRepository remoteRepository;
+    private ArtifactHandlerManager artifactHandlerManager;
+    private DependencyGraphBuilder dependencyGraphBuilder;
+    private MavenProject project;
+    private ProjectBuilder projectBuilder;
+    private RepositorySystemSession repositorySession;
+
+    // Test Subject
+    private ExtensionClassLoaderFactory factory;
+
+    @org.junit.jupiter.api.BeforeEach
+    void setUp() throws Exception {
+        artifact1 = projectArtifact();
+        artifact2 = localRepositoryDependencyArtifact();
+        artifact3 = remoteRepositoryDependencyArtifact();
+        log = mock(Log.class);
+        artifactResolver = mock(ArtifactResolver.class);
+        localRepository = mock(ArtifactRepository.class);
+        remoteRepository = mock(ArtifactRepository.class);
+        artifactHandlerManager = mock(ArtifactHandlerManager.class);
+        dependencyGraphBuilder = mock(DependencyGraphBuilder.class);
+        project = mock(MavenProject.class);
+        projectBuilder = mock(ProjectBuilder.class);
+        repositorySession = mock(RepositorySystemSession.class);
+
+        when(artifactResolver.resolve(any(ArtifactResolutionRequest.class)))
+                .thenAnswer(args -> resolved(args.getArgument(0, ArtifactResolutionRequest.class).getArtifact()));
+
+        factory = ExtensionClassLoaderFactory
+                .builder()
+                .log(log)
+                .project(project)
+                .projectBuilder(projectBuilder)
+                .dependencyGraphBuilder(dependencyGraphBuilder)
+                .artifactHandlerManager(artifactHandlerManager)
+                .artifactResolver(artifactResolver)
+                .localRepository(localRepository)
+                .remoteRepositories(Collections.singletonList(remoteRepository))
+                .repositorySession(repositorySession)
+                .build();
+    }
+
+    @org.junit.jupiter.api.Test
+    void createClassLoaderTest() throws Exception {
+        Set<Artifact> dependencyArtifacts = new TreeSet<>();
+        dependencyArtifacts.add(localRepositoryDependencyArtifact());
+        dependencyArtifacts.add(remoteRepositoryDependencyArtifact());
+
+        ExtensionClassLoader classLoader = factory.createClassLoader(dependencyArtifacts, null, projectArtifact());
+
+        String[] expectedURLs = new String[]{
+                "/path/to/service-api-nar",
+                "/path/to/service-nar"
+        };
+        assertEquals(expectedURLs.length, classLoader.getURLs().length);
+        List<String> expectedUrlsList = Arrays.asList(expectedURLs);
+        List<String> actualUrlsList = Arrays.stream(classLoader.getURLs()).map(URL::getFile).collect(Collectors.toList());
+        assertTrue(expectedUrlsList.containsAll(actualUrlsList));
+
+        InOrder inOrder = inOrder(artifactResolver);
+        for (ArtifactResolutionRequest req : getExpectedArtifactResolutionRequests()) {
+            inOrder.verify(artifactResolver).resolve(argThat(arg ->
+                req.getArtifact().getArtifactId().equals(arg.getArtifact().getArtifactId())
+                        && req.getLocalRepository() == arg.getLocalRepository()
+                        && req.getRemoteRepositories().equals(arg.getRemoteRepositories())
+            ));
+        }
+        verifyNoMoreInteractions(artifactResolver);
+    }
+    
+    private List<ArtifactResolutionRequest> getExpectedArtifactResolutionRequests() {
+        ArtifactResolutionRequest request1 = new ArtifactResolutionRequest();
+        request1.setArtifact(artifact2);
+        request1.setLocalRepository(localRepository);
+        request1.setRemoteRepositories(Collections.singletonList(remoteRepository));
+
+        ArtifactResolutionRequest request2 = new ArtifactResolutionRequest();
+        request2.setArtifact(artifact3);
+        request2.setLocalRepository(localRepository);
+        request2.setRemoteRepositories(Collections.singletonList(remoteRepository));
+
+        List<ArtifactResolutionRequest> resolutionRequests = new ArrayList<>();
+        resolutionRequests.add(request1);
+        resolutionRequests.add(request2);
+        return resolutionRequests;
+    }
+
+    private Artifact projectArtifact() {
+        Artifact artifact = new DefaultArtifact(
+                "org.apache.nifi",
+                "processor-nar",
+                "1.0.0",
+                "compile",
+                "nar",
+                "arbitrary",
+                mock(ArtifactHandler.class)
+        );
+        artifact.setFile(new File("/path/to/" + artifact.getArtifactId()));
+        return artifact;
+    }
+
+    private Artifact localRepositoryDependencyArtifact() {
+        Artifact artifact = new DefaultArtifact(
+                "org.apache.nifi",
+                "service-api-nar",
+                "1.0.0",
+                "compile",
+                "nar",
+                "arbitrary",
+                mock(ArtifactHandler.class)
+        );
+        artifact.setFile(null);
+        artifact.setRepository(localRepository);
+        return artifact;
+    }
+
+    private Artifact remoteRepositoryDependencyArtifact() {
+        Artifact artifact = new DefaultArtifact(
+                "org.apache.nifi",
+                "service-nar",
+                "1.0.0",
+                "provided",
+                "nar",
+                "arbitrary",
+                mock(ArtifactHandler.class)
+        );
+        artifact.setFile(null);
+        artifact.setRepository(remoteRepository);
+        return artifact;
+    }
+
+    private ArtifactResolutionResult resolved(Artifact artifact) {
+        Artifact resolvedArtifact = new DefaultArtifact(
+                artifact.getGroupId(),
+                artifact.getArtifactId(),
+                artifact.getVersion(),
+                artifact.getScope(),
+                artifact.getType(),
+                artifact.getClassifier(),
+                artifact.getArtifactHandler()
+        );
+        resolvedArtifact.setFile(new File("/path/to/" + artifact.getArtifactId()));
+        ArtifactResolutionResult result = new ArtifactResolutionResult();
+        result.setArtifacts(Collections.singleton(resolvedArtifact));
+        return result;
+    }
+}


### PR DESCRIPTION
... marked as provided.

This accounts for a change in maven-dependency-tree behavior (>= 3.1.0) to only resolve pom files and not full artifacts:
https://github.com/apache/maven-dependency-tree/commit/b330fa93b70e35c70a8afa75f0404cf47d5935d6 

We were benefiting from the previous behavior that garuanteed all NAR dependencies were fully resolved and therefore cached in the local repo by the time Extension Documentation Generation runs.

--- 

Note: Leaving this in draft state until I have a chance to look into adding unit tests.