### PR TITLE
NIFI-13258 - NAR Plugin - add parameter providers and flow analysis rules extension types

### DIFF
--- a/src/main/java/org/apache/nifi/NarMojo.java
+++ b/src/main/java/org/apache/nifi/NarMojo.java
@@ -620,6 +620,12 @@ public class NarMojo extends AbstractMojo {
 
                     final Set<ExtensionDefinition> reportingTaskDefinitions = extensionDefinitionFactory.discoverExtensions(ExtensionType.REPORTING_TASK);
                     writeDocumentation(reportingTaskDefinitions, extensionClassLoader, docWriterClass, xmlWriter, additionalDetailsDir);
+
+                    final Set<ExtensionDefinition> parameterProviderDefinitions = extensionDefinitionFactory.discoverExtensions(ExtensionType.PARAMETER_PROVIDER);
+                    writeDocumentation(parameterProviderDefinitions, extensionClassLoader, docWriterClass, xmlWriter, additionalDetailsDir);
+
+                    final Set<ExtensionDefinition> flowAnalysisRuleDefinitions = extensionDefinitionFactory.discoverExtensions(ExtensionType.FLOW_ANALYSIS_RULE);
+                    writeDocumentation(flowAnalysisRuleDefinitions, extensionClassLoader, docWriterClass, xmlWriter, additionalDetailsDir);
                 } finally {
                     if (currentContextClassLoader != null) {
                         Thread.currentThread().setContextClassLoader(currentContextClassLoader);

--- a/src/main/java/org/apache/nifi/extension/definition/ExtensionType.java
+++ b/src/main/java/org/apache/nifi/extension/definition/ExtensionType.java
@@ -22,6 +22,10 @@ public enum ExtensionType {
 
     CONTROLLER_SERVICE,
 
-    REPORTING_TASK;
+    REPORTING_TASK,
+
+    FLOW_ANALYSIS_RULE,
+
+    PARAMETER_PROVIDER;
 
 }

--- a/src/main/java/org/apache/nifi/extension/definition/extraction/ExtensionDefinitionFactory.java
+++ b/src/main/java/org/apache/nifi/extension/definition/extraction/ExtensionDefinitionFactory.java
@@ -42,6 +42,8 @@ public class ExtensionDefinitionFactory {
         INTERFACE_NAMES.put(ExtensionType.PROCESSOR, "org.apache.nifi.processor.Processor");
         INTERFACE_NAMES.put(ExtensionType.CONTROLLER_SERVICE, "org.apache.nifi.controller.ControllerService");
         INTERFACE_NAMES.put(ExtensionType.REPORTING_TASK, "org.apache.nifi.reporting.ReportingTask");
+        INTERFACE_NAMES.put(ExtensionType.FLOW_ANALYSIS_RULE, "org.apache.nifi.flowanalysis.FlowAnalysisRule");
+        INTERFACE_NAMES.put(ExtensionType.PARAMETER_PROVIDER, "org.apache.nifi.parameter.ParameterProvider");
     }
 
     private final ClassLoader extensionClassLoader;


### PR DESCRIPTION
Improve the NiFi NAR Maven plugin to add Parameter Providers and Flow Analysis Rules in the extension types.

We can confirm that in extension-manifest.xml we now have the expected data. Below examples:

````xml
    <extension>
      <name>org.apache.nifi.parameter.aws.AwsSecretsManagerParameterProvider</name>
      <type>PARAMETER_PROVIDER</type>
      <description>Fetches parameters from AWS SecretsManager.  Each secret becomes a Parameter group, which can map to a Parameter Context, with key/value pairs in the secret mapping to Parameters in the group.</description>
      <tags>
        <tag>aws</tag>
        <tag>secretsmanager</tag>
        <tag>secrets</tag>
        <tag>manager</tag>
      </tags>
      <properties>
        <property>
          <name>secret-name-pattern</name>
          <displayName>Secret Name Pattern</displayName>
          <description>A Regular Expression matching on Secret Name that identifies Secrets whose parameters should be fetched. Any secrets whose names do not match this pattern will not be fetched.</description>
          <defaultValue>.*</defaultValue>
          <required>true</required>
          <sensitive>false</sensitive>
          <expressionLanguageSupported>false</expressionLanguageSupported>
          <expressionLanguageScope>NONE</expressionLanguageScope>
          <dynamicallyModifiesClasspath>false</dynamicallyModifiesClasspath>
          <dynamic>false</dynamic>
        </property>
        <property>
          <name>aws-region</name>
          <displayName>Region</displayName>
          <description/>
          <defaultValue>us-west-2</defaultValue>
          <allowableValues>
            <allowableValue>
              <displayName>AWS GovCloud (US)</displayName>
              <value>us-gov-west-1</value>
              <description>AWS Region Code : us-gov-west-1</description>
            </allowableValue>
...
          </allowableValues>
          <required>true</required>
          <sensitive>false</sensitive>
          <expressionLanguageSupported>false</expressionLanguageSupported>
          <expressionLanguageScope>NONE</expressionLanguageScope>
          <dynamicallyModifiesClasspath>false</dynamicallyModifiesClasspath>
          <dynamic>false</dynamic>
        </property>
        <property>
          <name>aws-credentials-provider-service</name>
          <displayName>AWS Credentials Provider Service</displayName>
          <description>Service used to obtain an Amazon Web Services Credentials Provider</description>
          <controllerServiceDefinition>
            <className>org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderService</className>
            <groupId>org.apache.nifi</groupId>
            <artifactId>nifi-aws-service-api-nar</artifactId>
            <version>2.0.0-SNAPSHOT</version>
          </controllerServiceDefinition>
          <required>true</required>
          <sensitive>false</sensitive>
          <expressionLanguageSupported>false</expressionLanguageSupported>
          <expressionLanguageScope>NONE</expressionLanguageScope>
          <dynamicallyModifiesClasspath>false</dynamicallyModifiesClasspath>
          <dynamic>false</dynamic>
        </property>
        <property>
          <name>aws-communications-timeout</name>
          <displayName>Communications Timeout</displayName>
          <description/>
          <defaultValue>30 secs</defaultValue>
          <required>true</required>
          <sensitive>false</sensitive>
          <expressionLanguageSupported>false</expressionLanguageSupported>
          <expressionLanguageScope>NONE</expressionLanguageScope>
          <dynamicallyModifiesClasspath>false</dynamicallyModifiesClasspath>
          <dynamic>false</dynamic>
        </property>
        <property>
          <name>aws-ssl-context-service</name>
          <displayName>SSL Context Service</displayName>
          <description>Specifies an optional SSL Context Service that, if provided, will be used to create connections</description>
          <controllerServiceDefinition>
            <className>org.apache.nifi.ssl.SSLContextService</className>
            <groupId>org.apache.nifi</groupId>
            <artifactId>nifi-standard-services-api-nar</artifactId>
            <version>2.0.0-SNAPSHOT</version>
          </controllerServiceDefinition>
          <required>false</required>
          <sensitive>false</sensitive>
          <expressionLanguageSupported>false</expressionLanguageSupported>
          <expressionLanguageScope>NONE</expressionLanguageScope>
          <dynamicallyModifiesClasspath>false</dynamicallyModifiesClasspath>
          <dynamic>false</dynamic>
        </property>
      </properties>
    </extension>
````

````xml
    <extension>
      <name>org.apache.nifi.flowanalysis.rules.DisallowComponentType</name>
      <type>FLOW_ANALYSIS_RULE</type>
      <description>Produces rule violations for each component (i.e. processors or controller services) of a given type.</description>
      <tags>
        <tag>component</tag>
        <tag>processor</tag>
        <tag>controller service</tag>
        <tag>type</tag>
      </tags>
      <properties>
        <property>
          <name>component-type</name>
          <displayName>Component Type</displayName>
          <description>Components of the given type will produce a rule violation (i.e. they shouldn't exist). Either the simple or the fully qualified name of the type should be provided.</description>
          <required>true</required>
          <sensitive>false</sensitive>
          <expressionLanguageSupported>false</expressionLanguageSupported>
          <expressionLanguageScope>NONE</expressionLanguageScope>
          <dynamicallyModifiesClasspath>false</dynamicallyModifiesClasspath>
          <dynamic>false</dynamic>
        </property>
      </properties>
    </extension>
````