### PR TITLE
NIFI-14044 - Dependencies housekeeping for the NiFi NAR Maven Plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>32</version>
+        <version>33</version>
         <relativePath />
     </parent>
     <groupId>org.apache.nifi</groupId>
@@ -77,9 +77,9 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.build.outputTimestamp>2024-09-25T19:25:52Z</project.build.outputTimestamp>
         <inceptionYear>2014</inceptionYear>
-        <mockito.version>5.12.0</mockito.version>
-        <junit.version>5.10.2</junit.version>
-        <slf4j.version>2.0.13</slf4j.version>
+        <mockito.version>5.14.2</mockito.version>
+        <junit.version>5.11.3</junit.version>
+        <slf4j.version>2.0.16</slf4j.version>
     </properties>
     <build>
         <pluginManagement>
@@ -247,30 +247,30 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-archiver</artifactId>
-            <version>3.6.2</version>
+            <version>3.6.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <scope>provided</scope>
-            <version>3.9.6</version>
+            <version>3.9.9</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
-            <version>3.9.6</version>
+            <version>3.9.9</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-compat</artifactId>
             <scope>provided</scope>
-            <version>3.9.6</version>
+            <version>3.9.9</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-dependency-plugin</artifactId>
             <type>maven-plugin</type>
-            <version>3.6.1</version>
+            <version>3.8.1</version>
             <exclusions>
             	<exclusion>
             		<groupId>org.apache.maven.doxia</groupId>
@@ -297,18 +297,18 @@
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-dependency-tree</artifactId>
-            <version>3.2.1</version>
+            <version>3.3.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jar-plugin</artifactId>
-            <version>3.4.1</version>
+            <version>3.4.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <scope>provided</scope>
-            <version>3.13.0</version>
+            <version>3.15.1</version>
         </dependency>
         <!-- Test Dependencies -->
         <dependency>

--- a/src/main/java/org/apache/nifi/NarMojo.java
+++ b/src/main/java/org/apache/nifi/NarMojo.java
@@ -976,7 +976,7 @@ public class NarMojo extends AbstractMojo {
         // if this did something, we need to resolve the new artifacts
         if (StringUtils.isNotEmpty(copyDepClassifier)) {
             ArtifactTranslator translator = new ClassifierTypeTranslator(artifactHandlerManager, copyDepClassifier, type);
-            Set<ArtifactCoordinate> artifactCoordinates = translator.translate(artifacts, getLog());
+            Set<org.eclipse.aether.artifact.Artifact> artifactCoordinates = translator.translate(artifacts, getLog());
 
             status = filterMarkedDependencies(artifacts);
 


### PR DESCRIPTION
- Upgrade Apache from 32 to 33
- Upgrade Mockito from 5.12.0 to 5.14.2
- Upgrade JUnit from 5.10.2 to 5.11.3
- Upgrade SLF4J from 2.0.13 to 2.0.16
- Upgrade Maven archiver from 3.6.2 to 3.6.3
- Upgrade Maven Plugin API from 3.9.6 to 3.9.9
- Upgrade Maven Artifact from 3.9.6 to 3.9.9
- Upgrade Maven Compat from 3.9.6 to 3.9.9
- Upgrade Maven Dep Plugin from 3.6.1 to 3.8.1
- Upgrade Maven Dep Tree from 3.2.1 to 3.3.0
- Upgrade Maven JAR Plugin from 3.4.1 to 3.4.2
- Upgrade Maven Plugin Annotations from 3.13.0 to 3.15.1