### PR TITLE
NIFI-15675 - Add NAR signing support using JDK JarSigner

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,18 @@
         <inceptionYear>2014</inceptionYear>
         <mockito.version>5.21.0</mockito.version>
         <junit.version>6.0.3</junit.version>
+        <org.bouncycastle.version>1.83</org.bouncycastle.version>
         <slf4j.version>2.0.17</slf4j.version>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>${org.bouncycastle.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <build>
         <pluginManagement>
             <plugins>
@@ -336,6 +346,11 @@
             <scope>provided</scope>
         </dependency>
         <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/src/main/java/org/apache/nifi/NarMojo.java
+++ b/src/main/java/org/apache/nifi/NarMojo.java
@@ -86,9 +86,14 @@ import java.io.OutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.security.KeyStore;
+import java.security.cert.X509Certificate;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
@@ -105,6 +110,8 @@ import java.util.TreeSet;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.stream.Collectors;
+import java.util.zip.ZipFile;
+import jdk.security.jarsigner.JarSigner;
 
 /**
  * Packages the current project as an Apache NiFi Archive (NAR).
@@ -476,6 +483,51 @@ public class NarMojo extends AbstractMojo {
 
     @Parameter(property = "skipDocGeneration", defaultValue = "false")
     protected boolean skipDocGeneration;
+
+    /**
+     * Whether to sign the produced NAR file. Requires signKeystore, signStorepass, and signAlias.
+     */
+    @Parameter(property = "nar.sign", defaultValue = "false")
+    protected boolean sign;
+
+    /**
+     * Path to the keystore file containing the signing key.
+     */
+    @Parameter(property = "nar.sign.keystore")
+    protected String signKeystore;
+
+    /**
+     * Password for the keystore. Supports Maven password encryption via settings-security.xml.
+     */
+    @Parameter(property = "nar.sign.storepass")
+    protected String signStorepass;
+
+    /**
+     * Alias of the key entry in the keystore to use for signing.
+     */
+    @Parameter(property = "nar.sign.alias")
+    protected String signAlias;
+
+    /**
+     * Password for the key entry. Defaults to the keystore password if not specified.
+     */
+    @Parameter(property = "nar.sign.keypass")
+    protected String signKeypass;
+
+    /**
+     * Keystore type. Defaults to PKCS12.
+     */
+    @Parameter(property = "nar.sign.storetype", defaultValue = "PKCS12")
+    protected String signStoretype;
+
+    /**
+     * URL of a Time Stamping Authority (TSA) for timestamping the signature.
+     * When set, the signature includes a trusted timestamp so that it remains
+     * valid even after the signing certificate expires.
+     * Example: http://timestamp.digicert.com
+     */
+    @Parameter(property = "nar.sign.tsa")
+    protected String signTsa;
 
     /**
      * The {@link RepositorySystemSession} used for obtaining the local and remote artifact repositories.
@@ -1176,8 +1228,20 @@ public class NarMojo extends AbstractMojo {
     }
 
     private void makeNar() throws MojoExecutionException {
+        KeyStore.PrivateKeyEntry privateKeyEntry = null;
+
+        if (sign) {
+            privateKeyEntry = loadSigningKey();
+            final X509Certificate signerCert = (X509Certificate) privateKeyEntry.getCertificate();
+            archive.addManifestEntry("Nar-Signed-By", signerCert.getSubjectX500Principal().getName());
+        }
+
         final NarResult narResult = createArchive();
         final File narFile = narResult.getNarFile();
+
+        if (sign) {
+            signNar(narFile, privateKeyEntry);
+        }
 
         if (classifier != null) {
             projectHelper.attachArtifact(project, "nar", classifier, narFile);
@@ -1188,6 +1252,65 @@ public class NarMojo extends AbstractMojo {
         final File extensionDocsFile = narResult.getExtensionDocsFile();
         if (extensionDocsFile != null && !skipDocGeneration) {
             projectHelper.attachArtifact(project, "xml", "nar-extension-manifest", extensionDocsFile);
+        }
+    }
+
+    KeyStore.PrivateKeyEntry loadSigningKey() throws MojoExecutionException {
+        if (!notEmpty(signKeystore)) {
+            throw new MojoExecutionException("NAR signing is enabled but nar.sign.keystore is not configured");
+        }
+        if (!notEmpty(signStorepass)) {
+            throw new MojoExecutionException("NAR signing is enabled but nar.sign.storepass is not configured");
+        }
+        if (!notEmpty(signAlias)) {
+            throw new MojoExecutionException("NAR signing is enabled but nar.sign.alias is not configured");
+        }
+
+        try {
+            final KeyStore keyStore = KeyStore.getInstance(signStoretype);
+            try (final InputStream keystoreStream = Files.newInputStream(Path.of(signKeystore))) {
+                keyStore.load(keystoreStream, signStorepass.toCharArray());
+            }
+
+            final char[] keyPassword = notEmpty(signKeypass) ? signKeypass.toCharArray() : signStorepass.toCharArray();
+            final KeyStore.PrivateKeyEntry privateKeyEntry = (KeyStore.PrivateKeyEntry) keyStore.getEntry(
+                    signAlias, new KeyStore.PasswordProtection(keyPassword));
+
+            if (privateKeyEntry == null) {
+                throw new MojoExecutionException(
+                        "No private key entry found in keystore [%s] with alias [%s]".formatted(signKeystore, signAlias));
+            }
+
+            return privateKeyEntry;
+        } catch (final MojoExecutionException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw new MojoExecutionException("Failed to load signing key from keystore [%s]".formatted(signKeystore), e);
+        }
+    }
+
+    void signNar(final File narFile, final KeyStore.PrivateKeyEntry privateKeyEntry) throws MojoExecutionException {
+        getLog().info("Signing NAR: " + narFile.getName());
+
+        try {
+            final JarSigner.Builder builder = new JarSigner.Builder(privateKeyEntry).digestAlgorithm("SHA-256");
+
+            if (notEmpty(signTsa)) {
+                builder.tsa(URI.create(signTsa));
+            }
+
+            final JarSigner signer = builder.build();
+
+            final File signedFile = new File(narFile.getParentFile(), narFile.getName() + ".signed");
+            try (final ZipFile zipFile = new ZipFile(narFile);
+                 final OutputStream outputStream = new FileOutputStream(signedFile)) {
+                signer.sign(zipFile, outputStream);
+            }
+
+            Files.move(signedFile.toPath(), narFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            getLog().info("Signed NAR [%s] with alias [%s] from keystore [%s]".formatted(narFile.getName(), signAlias, signKeystore));
+        } catch (final Exception e) {
+            throw new MojoExecutionException("Failed to sign NAR: " + narFile.getName(), e);
         }
     }
 

--- a/src/test/java/org/apache/nifi/NarMojoTest.java
+++ b/src/test/java/org/apache/nifi/NarMojoTest.java
@@ -17,6 +17,12 @@
 package org.apache.nifi;
 
 import org.apache.maven.plugin.MojoExecutionException;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -24,12 +30,21 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.CodeSigner;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
 import java.security.KeyStore;
+import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
+import java.security.spec.ECGenParameterSpec;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
@@ -39,7 +54,6 @@ import java.util.jar.JarFile;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -59,22 +73,31 @@ class NarMojoTest {
     static void createTestKeystore() throws Exception {
         testKeystorePath = tempDir.resolve("test-keystore.p12");
 
-        final ProcessBuilder pb = new ProcessBuilder(
-                "keytool", "-genkeypair",
-                "-alias", TEST_ALIAS,
-                "-keyalg", "EC",
-                "-keysize", "256",
-                "-sigalg", "SHA256withECDSA",
-                "-validity", "365",
-                "-storetype", "PKCS12",
-                "-keystore", testKeystorePath.toString(),
-                "-storepass", TEST_PASSWORD,
-                "-dname", "CN=Test NAR Signer, O=Apache NiFi Test, C=US"
-        );
-        pb.inheritIO();
-        final Process process = pb.start();
-        assertEquals(0, process.waitFor(), "keytool must succeed");
-        assertTrue(Files.exists(testKeystorePath), "Keystore file must exist after generation");
+        final KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("EC");
+        keyPairGenerator.initialize(new ECGenParameterSpec("secp256r1"));
+        final KeyPair keyPair = keyPairGenerator.generateKeyPair();
+
+        final X500Name subject = new X500Name("CN=Test NAR Signer, O=Apache NiFi Test, C=US");
+        final Instant now = Instant.now();
+        final ContentSigner contentSigner = new JcaContentSignerBuilder("SHA256withECDSA").build(keyPair.getPrivate());
+        final X509CertificateHolder certificateHolder = new JcaX509v3CertificateBuilder(
+                subject,
+                BigInteger.ONE,
+                Date.from(now),
+                Date.from(now.plus(365, ChronoUnit.DAYS)),
+                subject,
+                keyPair.getPublic()
+        ).build(contentSigner);
+
+        final X509Certificate certificate = new JcaX509CertificateConverter().getCertificate(certificateHolder);
+
+        final KeyStore keyStore = KeyStore.getInstance("PKCS12");
+        keyStore.load(null, null);
+        keyStore.setKeyEntry(TEST_ALIAS, keyPair.getPrivate(), TEST_PASSWORD.toCharArray(), new Certificate[]{certificate});
+
+        try (final OutputStream out = Files.newOutputStream(testKeystorePath)) {
+            keyStore.store(out, TEST_PASSWORD.toCharArray());
+        }
     }
 
     @Test

--- a/src/test/java/org/apache/nifi/NarMojoTest.java
+++ b/src/test/java/org/apache/nifi/NarMojoTest.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.CodeSigner;
+import java.security.KeyStore;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NarMojoTest {
+
+    private static final String TEST_PASSWORD = "testpass";
+    private static final String TEST_ALIAS = "test-signer";
+
+    @TempDir
+    static Path tempDir;
+
+    private static Path testKeystorePath;
+
+    @BeforeAll
+    static void createTestKeystore() throws Exception {
+        testKeystorePath = tempDir.resolve("test-keystore.p12");
+
+        final ProcessBuilder pb = new ProcessBuilder(
+                "keytool", "-genkeypair",
+                "-alias", TEST_ALIAS,
+                "-keyalg", "EC",
+                "-keysize", "256",
+                "-sigalg", "SHA256withECDSA",
+                "-validity", "365",
+                "-storetype", "PKCS12",
+                "-keystore", testKeystorePath.toString(),
+                "-storepass", TEST_PASSWORD,
+                "-dname", "CN=Test NAR Signer, O=Apache NiFi Test, C=US"
+        );
+        pb.inheritIO();
+        final Process process = pb.start();
+        assertEquals(0, process.waitFor(), "keytool must succeed");
+        assertTrue(Files.exists(testKeystorePath), "Keystore file must exist after generation");
+    }
+
+    @Test
+    void testSignNar() throws Exception {
+        final File narFile = createTestNar("test-sign");
+
+        final NarMojo mojo = createSigningMojo();
+        final KeyStore.PrivateKeyEntry keyEntry = mojo.loadSigningKey();
+        mojo.signNar(narFile, keyEntry);
+
+        try (final JarFile jarFile = new JarFile(narFile, true)) {
+            final List<JarEntry> signableEntries = readAllEntriesAndCollectSignable(jarFile);
+            assertFalse(signableEntries.isEmpty(), "NAR must contain signable entries");
+
+            for (final JarEntry entry : signableEntries) {
+                final CodeSigner[] signers = entry.getCodeSigners();
+                assertNotNull(signers, "Entry [%s] must have code signers".formatted(entry.getName()));
+                assertTrue(signers.length > 0, "Entry [%s] must have at least one code signer".formatted(entry.getName()));
+            }
+        }
+    }
+
+    @Test
+    void testLoadSigningKeyReturnsCertificateWithExpectedDn() throws Exception {
+        final NarMojo mojo = createSigningMojo();
+        final KeyStore.PrivateKeyEntry keyEntry = mojo.loadSigningKey();
+
+        assertNotNull(keyEntry);
+        final X509Certificate cert = (X509Certificate) keyEntry.getCertificate();
+        final String dn = cert.getSubjectX500Principal().getName();
+        assertTrue(dn.contains("CN=Test NAR Signer"), "Signer DN must contain the expected CN, got: " + dn);
+    }
+
+    @Test
+    void testSignNarDisabledByDefault() throws Exception {
+        final File narFile = createTestNar("test-unsigned");
+
+        try (final JarFile jarFile = new JarFile(narFile, true)) {
+            final List<JarEntry> signableEntries = readAllEntriesAndCollectSignable(jarFile);
+            for (final JarEntry entry : signableEntries) {
+                final CodeSigner[] signers = entry.getCodeSigners();
+                assertTrue(signers == null || signers.length == 0,
+                        "Unsigned NAR entry [%s] must not have code signers".formatted(entry.getName()));
+            }
+        }
+    }
+
+    @Test
+    void testSignNarMissingKeystore() {
+        final NarMojo mojo = new NarMojo();
+        mojo.signKeystore = null;
+        mojo.signStorepass = TEST_PASSWORD;
+        mojo.signAlias = TEST_ALIAS;
+        mojo.signStoretype = "PKCS12";
+
+        final MojoExecutionException exception = assertThrows(MojoExecutionException.class, mojo::loadSigningKey);
+        assertTrue(exception.getMessage().contains("nar.sign.keystore"));
+    }
+
+    @Test
+    void testSignNarMissingStorepass() {
+        final NarMojo mojo = new NarMojo();
+        mojo.signKeystore = testKeystorePath.toString();
+        mojo.signStorepass = null;
+        mojo.signAlias = TEST_ALIAS;
+        mojo.signStoretype = "PKCS12";
+
+        final MojoExecutionException exception = assertThrows(MojoExecutionException.class, mojo::loadSigningKey);
+        assertTrue(exception.getMessage().contains("nar.sign.storepass"));
+    }
+
+    @Test
+    void testSignNarMissingAlias() {
+        final NarMojo mojo = new NarMojo();
+        mojo.signKeystore = testKeystorePath.toString();
+        mojo.signStorepass = TEST_PASSWORD;
+        mojo.signAlias = null;
+        mojo.signStoretype = "PKCS12";
+
+        final MojoExecutionException exception = assertThrows(MojoExecutionException.class, mojo::loadSigningKey);
+        assertTrue(exception.getMessage().contains("nar.sign.alias"));
+    }
+
+    @Test
+    void testSignNarInvalidAlias() {
+        final NarMojo mojo = createSigningMojo();
+        mojo.signAlias = "nonexistent-alias";
+
+        final MojoExecutionException exception = assertThrows(MojoExecutionException.class, mojo::loadSigningKey);
+        assertNotNull(exception.getMessage());
+    }
+
+    @Test
+    void testSignNarPreservesContent() throws Exception {
+        final File narFile = createTestNar("test-preserve");
+
+        final Set<String> originalEntries = new HashSet<>();
+        try (final JarFile jarFile = new JarFile(narFile)) {
+            final Enumeration<JarEntry> entries = jarFile.entries();
+            while (entries.hasMoreElements()) {
+                originalEntries.add(entries.nextElement().getName());
+            }
+        }
+
+        final NarMojo mojo = createSigningMojo();
+        final KeyStore.PrivateKeyEntry keyEntry = mojo.loadSigningKey();
+        mojo.signNar(narFile, keyEntry);
+
+        try (final JarFile jarFile = new JarFile(narFile, true)) {
+            final Enumeration<JarEntry> entries = jarFile.entries();
+            final Set<String> signedEntries = new HashSet<>();
+            while (entries.hasMoreElements()) {
+                final JarEntry entry = entries.nextElement();
+                signedEntries.add(entry.getName());
+                try (final InputStream is = jarFile.getInputStream(entry)) {
+                    assertNotNull(is.readAllBytes(), "Entry [%s] must be readable after signing".formatted(entry.getName()));
+                }
+            }
+
+            for (final String original : originalEntries) {
+                assertTrue(signedEntries.contains(original),
+                        "Original entry [%s] must still be present after signing".formatted(original));
+            }
+        }
+    }
+
+    private NarMojo createSigningMojo() {
+        final NarMojo mojo = new NarMojo();
+        mojo.sign = true;
+        mojo.signKeystore = testKeystorePath.toString();
+        mojo.signStorepass = TEST_PASSWORD;
+        mojo.signAlias = TEST_ALIAS;
+        mojo.signStoretype = "PKCS12";
+        return mojo;
+    }
+
+    private File createTestNar(final String name) throws Exception {
+        final Path narPath = tempDir.resolve(name + ".nar");
+        final Manifest manifest = new Manifest();
+        manifest.getMainAttributes().putValue("Manifest-Version", "1.0");
+        manifest.getMainAttributes().putValue("Nar-Id", name);
+        manifest.getMainAttributes().putValue("Nar-Group", "org.apache.nifi.test");
+        manifest.getMainAttributes().putValue("Nar-Version", "1.0.0");
+
+        try (final JarOutputStream jos = new JarOutputStream(new FileOutputStream(narPath.toFile()), manifest)) {
+            jos.putNextEntry(new JarEntry("META-INF/bundled-dependencies/"));
+            jos.closeEntry();
+
+            jos.putNextEntry(new JarEntry("META-INF/bundled-dependencies/test-lib.jar"));
+            jos.write("fake jar content for testing".getBytes());
+            jos.closeEntry();
+
+            jos.putNextEntry(new JarEntry("META-INF/docs/extension-manifest.xml"));
+            jos.write("<extensionManifest/>".getBytes());
+            jos.closeEntry();
+        }
+
+        return narPath.toFile();
+    }
+
+    private List<JarEntry> readAllEntriesAndCollectSignable(final JarFile jarFile) throws Exception {
+        final Enumeration<JarEntry> entries = jarFile.entries();
+        final List<JarEntry> signableEntries = new ArrayList<>();
+
+        while (entries.hasMoreElements()) {
+            final JarEntry entry = entries.nextElement();
+            try (final InputStream is = jarFile.getInputStream(entry)) {
+                is.readAllBytes();
+            }
+            if (!entry.isDirectory() && !isSignatureRelatedEntry(entry.getName())) {
+                signableEntries.add(entry);
+            }
+        }
+
+        return signableEntries;
+    }
+
+    private boolean isSignatureRelatedEntry(final String name) {
+        if (name.equals("META-INF/MANIFEST.MF")) {
+            return true;
+        }
+        if (!name.startsWith("META-INF/")) {
+            return false;
+        }
+        final String upperName = name.toUpperCase();
+        return (upperName.endsWith(".SF") || upperName.endsWith(".RSA") || upperName.endsWith(".EC") || upperName.endsWith(".DSA"))
+                && name.indexOf('/', "META-INF/".length()) == -1;
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NIFI-15675

## Add NAR signing support using JDK JarSigner

When NiFi dynamically downloads or auto-loads NARs from external sources, there is currently no mechanism to verify that a NAR has not been tampered with or that it originates from a trusted publisher. This is the build-side prerequisite for enabling signature verification in the NiFi runtime.

Since a NAR is structurally a JAR, the JDK's built-in JAR signing mechanism is the natural fit. This issue covers adding optional signing parameters to the existing goal in the plugin. Signing is disabled by default for full backward compatibility. A follow-up issue will cover runtime verification in NiFi itself.

- Adds optional NAR signing to the existing `nar` goal using the JDK's `jdk.security.jarsigner.JarSigner` API
- Signing is disabled by default (`nar.sign=false`) — fully backward compatible, no behavioral change unless explicitly opted in
- After `createArchive()` produces the NAR, the new `signNar()` step signs it in place using the configured keystore, then the signed NAR is registered as the project artifact

## Configuration

Seven new parameters on the `nar` goal, all optional:

| Parameter | Property | Default | Description |
|-----------|----------|---------|-------------|
| `sign` | `nar.sign` | `false` | Enable signing |
| `signKeystore` | `nar.sign.keystore` | — | Path to PKCS12/JKS keystore |
| `signStorepass` | `nar.sign.storepass` | — | Keystore password |
| `signAlias` | `nar.sign.alias` | — | Key alias |
| `signKeypass` | `nar.sign.keypass` | — | Key password (defaults to storepass) |
| `signStoretype` | `nar.sign.storetype` | `PKCS12` | Keystore type |
| `signTsa` | `nar.sign.tsa` | — | TSA URL for timestamping |

Minimal usage:
```xml
<configuration>
    <sign>true</sign>
    <signKeystore>/path/to/keystore.p12</signKeystore>
    <signStorepass>${env.NAR_SIGN_PASSWORD}</signStorepass>
    <signAlias>nar-signer</signAlias>
</configuration>
```

Or entirely via command line with no POM changes:
```bash
mvn package -Dnar.sign=true -Dnar.sign.keystore=... -Dnar.sign.storepass=... -Dnar.sign.alias=...
```

Signed NARs can be verified with standard JDK tooling: `jarsigner -verify -verbose -certs target/my.nar`

## Approach

A NAR is structurally a JAR. Rather than inventing a custom signature format, this uses the JDK's `JarSigner` API (available since Java 9, stable in Java 21) which signs each entry inside the archive with SHA-256 digests and produces standard PKCS#7 signature blocks. This means:

- Zero custom signature format — uses the decades-old JAR signing standard
- Interoperable — verifiable with `jarsigner -verify` by anyone
- No new dependencies — `jdk.security.jarsigner.JarSigner` is part of the JDK itself
- No changes to the NAR file format — the signature lives in `META-INF/` like any signed JAR

## Verification building nifi-aws-nar

### NAR build

```
...
[INFO] Building jar: /.../nifi/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-nar/target/nifi-aws-nar-2.9.0-SNAPSHOT.nar
[INFO] Signing NAR: nifi-aws-nar-2.9.0-SNAPSHOT.nar
[INFO] Signed NAR [nifi-aws-nar-2.9.0-SNAPSHOT.nar] with alias [nar-signer] from keystore [/.../nar-signing/nar-signing.p12]
...
```

### NAR content

```
% unzip -l ./nifi-aws-nar/target/nifi-aws-nar-2.9.0-SNAPSHOT.nar | head
Archive:  ./nifi-aws-nar/target/nifi-aws-nar-2.9.0-SNAPSHOT.nar
  Length      Date    Time    Name
---------  ---------- -----   ----
    18178  03-06-2026 10:36   META-INF/MANIFEST.MF
    17984  03-06-2026 10:36   META-INF/SIGNER.SF
      820  03-06-2026 10:36   META-INF/SIGNER.EC
        0  02-13-2026 22:38   META-INF/
    24862  02-13-2026 22:38   META-INF/DEPENDENCIES
    11608  02-13-2026 22:38   META-INF/LICENSE
     8303  02-13-2026 22:38   META-INF/NOTICE
```

### Verification

```
% jarsigner -verify -verbose -certs ./nifi-aws-nar/target/nifi-aws-nar-2.9.0-SNAPSHOT.nar

s      18178 Fri Mar 06 10:36:46 CET 2026 META-INF/MANIFEST.MF

      >>> Signer
      X.509, CN=Your Name, O=Your Organization, C=US
      Signature algorithm: SHA256withECDSA, 256-bit key
      [certificate is valid from 06/03/2026, 10:27 to 03/03/2036, 10:27]
      [Invalid certificate chain: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target]

       17984 Fri Mar 06 10:36:46 CET 2026 META-INF/SIGNER.SF
         820 Fri Mar 06 10:36:46 CET 2026 META-INF/SIGNER.EC
...

- Signed by "CN=Your Name, O=Your Organization, C=US"
    Digest algorithm: SHA-256
    Signature algorithm: SHA384withECDSA, 256-bit key

jar verified.
```

### Manifest

```
% unzip -p ./nifi-aws-nar/target/nifi-aws-nar-2.9.0-SNAPSHOT.nar META-INF/MANIFEST.MF                                                   
Manifest-Version: 1.0
Created-By: Apache NiFi Nar Maven Plugin 2.4.0-SNAPSHOT
Java-Version: 21
Build-Jdk-Spec: 21
Nar-Signed-By: CN=Your Name,O=Your Organization,C=US
Nar-Id: nifi-aws-nar
Nar-Group: org.apache.nifi
Nar-Version: 2.9.0-SNAPSHOT
Nar-Dependency-Group: org.apache.nifi
Nar-Dependency-Id: nifi-aws-service-api-nar
Nar-Dependency-Version: 2.9.0-SNAPSHOT
Build-Tag: HEAD
Build-Timestamp: 2026-02-13T22:38:02Z
Clone-During-Instance-Class-Loading: false

Name: META-INF/bundled-dependencies/nifi-aws-regions-2.9.0-SNAPSHOT.jar
SHA-256-Digest: Oe0oiBk1HeuiqF2PPV2iQEMeNoWeVrhG1CP9nV0DTpQ=

Name: META-INF/bundled-dependencies/wire-grpc-client-jvm-5.2.0.jar
SHA-256-Digest: sgRBcicsGM0kr1Bsgoe1tIBSZ+/4abZtLYUhqLfyISs=

Name: META-INF/bundled-dependencies/jakarta.activation-api-2.1.4.jar
SHA-256-Digest: ydtSEAzmyKrJXMOQdflXINLlYbEfgFG4HBIa1O/9cAQ=
...
```