### PR TITLE
NIFI-15676 - Add support for custom entries in NAR Manifest

### DIFF
--- a/src/main/java/org/apache/nifi/NarMojo.java
+++ b/src/main/java/org/apache/nifi/NarMojo.java
@@ -123,7 +123,6 @@ public class NarMojo extends AbstractMojo {
     private static final String DOCUMENTATION_WRITER_CLASS_NAME = "org.apache.nifi.documentation.xml.XmlDocumentationWriter";
     private static final String CONNECTOR_DOCUMENTATION_WRITER_CLASS_NAME = "org.apache.nifi.documentation.xml.XmlConnectorDocumentationWriter";
 
-    static final String NAR_CUSTOM_PREFIX = "Nar-Custom-";
     static final Pattern VALID_MANIFEST_KEY_PATTERN = Pattern.compile("[A-Za-z0-9_-]+");
 
     private static final String[] DEFAULT_EXCLUDES = new String[]{"**/package.html"};
@@ -482,11 +481,11 @@ public class NarMojo extends AbstractMojo {
     protected boolean skipDocGeneration;
 
     /**
-     * Custom key/value pairs to include in the NAR manifest with a {@code Nar-Custom-} prefix.
+     * Additional key/value pairs to include in the NAR manifest.
      * Keys must match the JAR manifest attribute name specification: {@code [A-Za-z0-9_-]+}.
      */
-    @Parameter(property = "customManifestEntries")
-    protected Map<String, String> customManifestEntries;
+    @Parameter(property = "manifestEntries")
+    protected Map<String, String> manifestEntries;
 
     /**
      * The {@link RepositorySystemSession} used for obtaining the local and remote artifact repositories.
@@ -1277,10 +1276,10 @@ public class NarMojo extends AbstractMojo {
 
             archive.addManifestEntry("Clone-During-Instance-Class-Loading", String.valueOf(cloneDuringInstanceClassLoading));
 
-            if (customManifestEntries != null) {
-                validateCustomManifestEntryKeys(customManifestEntries);
-                for (final Map.Entry<String, String> entry : customManifestEntries.entrySet()) {
-                    archive.addManifestEntry(NAR_CUSTOM_PREFIX + entry.getKey(), entry.getValue());
+            if (manifestEntries != null) {
+                validateManifestEntryKeys(manifestEntries);
+                for (final Map.Entry<String, String> entry : manifestEntries.entrySet()) {
+                    archive.addManifestEntry(entry.getKey(), entry.getValue());
                 }
             }
 
@@ -1291,14 +1290,14 @@ public class NarMojo extends AbstractMojo {
         }
     }
 
-    static void validateCustomManifestEntryKeys(final Map<String, String> entries) throws MojoExecutionException {
+    static void validateManifestEntryKeys(final Map<String, String> entries) throws MojoExecutionException {
         for (final String key : entries.keySet()) {
             if (key == null || key.isEmpty()) {
-                throw new MojoExecutionException("Custom manifest entry key must not be null or empty");
+                throw new MojoExecutionException("Manifest entry key must not be null or empty");
             }
             if (!VALID_MANIFEST_KEY_PATTERN.matcher(key).matches()) {
                 throw new MojoExecutionException(
-                        "Custom manifest entry key '%s' contains invalid characters. Keys must match [A-Za-z0-9_-]+".formatted(key));
+                        "Manifest entry key '%s' contains invalid characters. Keys must match [A-Za-z0-9_-]+".formatted(key));
             }
         }
     }

--- a/src/main/java/org/apache/nifi/NarMojo.java
+++ b/src/main/java/org/apache/nifi/NarMojo.java
@@ -104,6 +104,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -121,6 +122,9 @@ public class NarMojo extends AbstractMojo {
     private static final String CONNECTOR_CLASS_NAME = "org.apache.nifi.components.connector.Connector";
     private static final String DOCUMENTATION_WRITER_CLASS_NAME = "org.apache.nifi.documentation.xml.XmlDocumentationWriter";
     private static final String CONNECTOR_DOCUMENTATION_WRITER_CLASS_NAME = "org.apache.nifi.documentation.xml.XmlConnectorDocumentationWriter";
+
+    static final String NAR_CUSTOM_PREFIX = "Nar-Custom-";
+    static final Pattern VALID_MANIFEST_KEY_PATTERN = Pattern.compile("[A-Za-z0-9_-]+");
 
     private static final String[] DEFAULT_EXCLUDES = new String[]{"**/package.html"};
     private static final String[] DEFAULT_INCLUDES = new String[]{"**/**"};
@@ -476,6 +480,13 @@ public class NarMojo extends AbstractMojo {
 
     @Parameter(property = "skipDocGeneration", defaultValue = "false")
     protected boolean skipDocGeneration;
+
+    /**
+     * Custom key/value pairs to include in the NAR manifest with a {@code Nar-Custom-} prefix.
+     * Keys must match the JAR manifest attribute name specification: {@code [A-Za-z0-9_-]+}.
+     */
+    @Parameter(property = "customManifestEntries")
+    protected Map<String, String> customManifestEntries;
 
     /**
      * The {@link RepositorySystemSession} used for obtaining the local and remote artifact repositories.
@@ -1266,10 +1277,29 @@ public class NarMojo extends AbstractMojo {
 
             archive.addManifestEntry("Clone-During-Instance-Class-Loading", String.valueOf(cloneDuringInstanceClassLoading));
 
+            if (customManifestEntries != null) {
+                validateCustomManifestEntryKeys(customManifestEntries);
+                for (final Map.Entry<String, String> entry : customManifestEntries.entrySet()) {
+                    archive.addManifestEntry(NAR_CUSTOM_PREFIX + entry.getKey(), entry.getValue());
+                }
+            }
+
             archiver.createArchive(session, project, archive);
             return new NarResult(narFile, extensionDocsFile);
         } catch (ArchiverException | MojoExecutionException | ManifestException | IOException | DependencyResolutionRequiredException e) {
             throw new MojoExecutionException("Error assembling NAR", e);
+        }
+    }
+
+    static void validateCustomManifestEntryKeys(final Map<String, String> entries) throws MojoExecutionException {
+        for (final String key : entries.keySet()) {
+            if (key == null || key.isEmpty()) {
+                throw new MojoExecutionException("Custom manifest entry key must not be null or empty");
+            }
+            if (!VALID_MANIFEST_KEY_PATTERN.matcher(key).matches()) {
+                throw new MojoExecutionException(
+                        "Custom manifest entry key '%s' contains invalid characters. Keys must match [A-Za-z0-9_-]+".formatted(key));
+            }
         }
     }
 

--- a/src/test/java/org/apache/nifi/NarMojoTest.java
+++ b/src/test/java/org/apache/nifi/NarMojoTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class NarMojoTest {
+
+    @Test
+    void testValidateCustomManifestEntryKeysAcceptsValidKeys() throws MojoExecutionException {
+        final Map<String, String> entries = new LinkedHashMap<>();
+        entries.put("vendor", "Acme Corp");
+        entries.put("support-url", "https://acme.corp/support");
+        entries.put("build_number", "42");
+        entries.put("Tier-1", "gold");
+        entries.put("ABC123", "test");
+
+        NarMojo.validateCustomManifestEntryKeys(entries);
+    }
+
+    @Test
+    void testValidateCustomManifestEntryKeysRejectsEmptyKey() {
+        final Map<String, String> entries = new HashMap<>();
+        entries.put("", "some-value");
+
+        final MojoExecutionException exception = assertThrows(MojoExecutionException.class,
+                () -> NarMojo.validateCustomManifestEntryKeys(entries));
+        assertEquals("Custom manifest entry key must not be null or empty", exception.getMessage());
+    }
+
+    @Test
+    void testValidateCustomManifestEntryKeysRejectsKeyWithSpaces() {
+        final Map<String, String> entries = new HashMap<>();
+        entries.put("my key", "value");
+
+        final MojoExecutionException exception = assertThrows(MojoExecutionException.class,
+                () -> NarMojo.validateCustomManifestEntryKeys(entries));
+        assertEquals("Custom manifest entry key 'my key' contains invalid characters. Keys must match [A-Za-z0-9_-]+", exception.getMessage());
+    }
+
+    @Test
+    void testValidateCustomManifestEntryKeysRejectsKeyWithColon() {
+        final Map<String, String> entries = new HashMap<>();
+        entries.put("key:name", "value");
+
+        final MojoExecutionException exception = assertThrows(MojoExecutionException.class,
+                () -> NarMojo.validateCustomManifestEntryKeys(entries));
+        assertEquals("Custom manifest entry key 'key:name' contains invalid characters. Keys must match [A-Za-z0-9_-]+", exception.getMessage());
+    }
+
+    @Test
+    void testValidateCustomManifestEntryKeysRejectsKeyWithDot() {
+        final Map<String, String> entries = new HashMap<>();
+        entries.put("key.name", "value");
+
+        final MojoExecutionException exception = assertThrows(MojoExecutionException.class,
+                () -> NarMojo.validateCustomManifestEntryKeys(entries));
+        assertEquals("Custom manifest entry key 'key.name' contains invalid characters. Keys must match [A-Za-z0-9_-]+", exception.getMessage());
+    }
+
+    @Test
+    void testValidateCustomManifestEntryKeysAcceptsEmptyMap() throws MojoExecutionException {
+        NarMojo.validateCustomManifestEntryKeys(Map.of());
+    }
+
+    @Test
+    void testNarCustomPrefixValue() {
+        assertEquals("Nar-Custom-", NarMojo.NAR_CUSTOM_PREFIX);
+    }
+}

--- a/src/test/java/org/apache/nifi/NarMojoTest.java
+++ b/src/test/java/org/apache/nifi/NarMojoTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class NarMojoTest {
 
     @Test
-    void testValidateCustomManifestEntryKeysAcceptsValidKeys() throws MojoExecutionException {
+    void testValidateManifestEntryKeysAcceptsValidKeys() throws MojoExecutionException {
         final Map<String, String> entries = new LinkedHashMap<>();
         entries.put("vendor", "Acme Corp");
         entries.put("support-url", "https://acme.corp/support");
@@ -37,56 +37,51 @@ class NarMojoTest {
         entries.put("Tier-1", "gold");
         entries.put("ABC123", "test");
 
-        NarMojo.validateCustomManifestEntryKeys(entries);
+        NarMojo.validateManifestEntryKeys(entries);
     }
 
     @Test
-    void testValidateCustomManifestEntryKeysRejectsEmptyKey() {
+    void testValidateManifestEntryKeysRejectsEmptyKey() {
         final Map<String, String> entries = new HashMap<>();
         entries.put("", "some-value");
 
         final MojoExecutionException exception = assertThrows(MojoExecutionException.class,
-                () -> NarMojo.validateCustomManifestEntryKeys(entries));
-        assertEquals("Custom manifest entry key must not be null or empty", exception.getMessage());
+                () -> NarMojo.validateManifestEntryKeys(entries));
+        assertEquals("Manifest entry key must not be null or empty", exception.getMessage());
     }
 
     @Test
-    void testValidateCustomManifestEntryKeysRejectsKeyWithSpaces() {
+    void testValidateManifestEntryKeysRejectsKeyWithSpaces() {
         final Map<String, String> entries = new HashMap<>();
         entries.put("my key", "value");
 
         final MojoExecutionException exception = assertThrows(MojoExecutionException.class,
-                () -> NarMojo.validateCustomManifestEntryKeys(entries));
-        assertEquals("Custom manifest entry key 'my key' contains invalid characters. Keys must match [A-Za-z0-9_-]+", exception.getMessage());
+                () -> NarMojo.validateManifestEntryKeys(entries));
+        assertEquals("Manifest entry key 'my key' contains invalid characters. Keys must match [A-Za-z0-9_-]+", exception.getMessage());
     }
 
     @Test
-    void testValidateCustomManifestEntryKeysRejectsKeyWithColon() {
+    void testValidateManifestEntryKeysRejectsKeyWithColon() {
         final Map<String, String> entries = new HashMap<>();
         entries.put("key:name", "value");
 
         final MojoExecutionException exception = assertThrows(MojoExecutionException.class,
-                () -> NarMojo.validateCustomManifestEntryKeys(entries));
-        assertEquals("Custom manifest entry key 'key:name' contains invalid characters. Keys must match [A-Za-z0-9_-]+", exception.getMessage());
+                () -> NarMojo.validateManifestEntryKeys(entries));
+        assertEquals("Manifest entry key 'key:name' contains invalid characters. Keys must match [A-Za-z0-9_-]+", exception.getMessage());
     }
 
     @Test
-    void testValidateCustomManifestEntryKeysRejectsKeyWithDot() {
+    void testValidateManifestEntryKeysRejectsKeyWithDot() {
         final Map<String, String> entries = new HashMap<>();
         entries.put("key.name", "value");
 
         final MojoExecutionException exception = assertThrows(MojoExecutionException.class,
-                () -> NarMojo.validateCustomManifestEntryKeys(entries));
-        assertEquals("Custom manifest entry key 'key.name' contains invalid characters. Keys must match [A-Za-z0-9_-]+", exception.getMessage());
+                () -> NarMojo.validateManifestEntryKeys(entries));
+        assertEquals("Manifest entry key 'key.name' contains invalid characters. Keys must match [A-Za-z0-9_-]+", exception.getMessage());
     }
 
     @Test
-    void testValidateCustomManifestEntryKeysAcceptsEmptyMap() throws MojoExecutionException {
-        NarMojo.validateCustomManifestEntryKeys(Map.of());
-    }
-
-    @Test
-    void testNarCustomPrefixValue() {
-        assertEquals("Nar-Custom-", NarMojo.NAR_CUSTOM_PREFIX);
+    void testValidateManifestEntryKeysAcceptsEmptyMap() throws MojoExecutionException {
+        NarMojo.validateManifestEntryKeys(Map.of());
     }
 }


### PR DESCRIPTION
NIFI-15676 - Add support for custom entries in NAR Manifest

### Configuration

```
            <plugin>
                <groupId>org.apache.nifi</groupId>
                <artifactId>nifi-nar-maven-plugin</artifactId>
                <extensions>true</extensions>
                <configuration>
                    <enforceDocGeneration>true</enforceDocGeneration>
                    <customManifestEntries>
                        <repo-url>https://github.com/apache/nifi</repo-url>
                    </customManifestEntries>
                </configuration>
            </plugin>
```

### Result

```
% unzip -p ./nifi-aws-nar/target/nifi-aws-nar-2.9.0-SNAPSHOT.nar META-INF/MANIFEST.MF
Manifest-Version: 1.0
Created-By: Apache NiFi Nar Maven Plugin 2.4.0-SNAPSHOT
Java-Version: 21
Build-Jdk-Spec: 21
Nar-Id: nifi-aws-nar
Nar-Group: org.apache.nifi
Nar-Version: 2.9.0-SNAPSHOT
Nar-Dependency-Group: org.apache.nifi
Nar-Dependency-Id: nifi-aws-service-api-nar
Nar-Dependency-Version: 2.9.0-SNAPSHOT
Build-Tag: HEAD
Build-Timestamp: 2026-02-13T22:38:02Z
Clone-During-Instance-Class-Loading: false
Nar-Custom-repo-url: https://github.com/apache/nifi
```